### PR TITLE
Update Docker image tag in workflow

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -28,4 +28,4 @@ jobs:
           context: .  # Docker build context
           file: ./Dockerfile  # Path to your Dockerfile
           push: true
-          tags: ghcr.io/Propriotec/TwelveData-UDF-API:latest
+          tags: ghcr.io/propriotec/twelvedata-udf-api:latest


### PR DESCRIPTION
The commit changes the Docker image tag name in the GitHub Actions workflow file, 'docker-build.yml'. The case of the characters in the image tag name was adjusted for consistency and standardization.